### PR TITLE
feat: send xcm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ pub mod pallet {
 
 		type Token: Inspect<Self::AccountId, Balance = Self::Amount> + Transfer<Self::AccountId>;
 
-		type Xcm: SendXcm;
+		type Xcm: traits::Xcm;
 	}
 
 	// AutoPay
@@ -1015,12 +1015,8 @@ pub mod pallet {
 			destination: impl Into<MultiLocation>,
 			mut message: Xcm<()>,
 		) -> Result<(), Error<T>> {
-			// Descend origin to signify pallet call
-			message
-				.0
-				.insert(0, DescendOrigin(X1(PalletInstance(Pallet::<T>::index() as u8))));
-
-			T::Xcm::send_xcm(destination, message).map_err(|e| match e {
+			let interior = X1(PalletInstance(Pallet::<T>::index() as u8));
+			<T::Xcm as traits::Xcm>::send_xcm(interior, destination, message).map_err(|e| match e {
 				SendError::CannotReachDestination(..) => Error::<T>::Unreachable,
 				_ => Error::<T>::SendFailure,
 			})

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod tests;
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 mod contracts;
-mod traits;
+pub mod traits;
 mod types;
 pub mod xcm;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,15 @@
 use sp_std::vec::Vec;
+use xcm::prelude::*;
+
+// Simple trait to avoid taking a hard dependency on pallet-xcm.
+pub trait Xcm {
+	fn send_xcm(
+		interior: impl Into<Junctions>,
+		dest: impl Into<MultiLocation>,
+		message: xcm::v2::Xcm<()>,
+	) -> Result<(), SendError>;
+}
+
 /// This traits helps pallets read data from Tellor
 pub trait UsingTellor<AccountId, QueryId, Timestamp, Value> {
 	/// Retrieves the next value for the query identifer after the specified timestamp.


### PR DESCRIPTION
Use pallet_xcm::send_xcm via trait for sending cross-chain messages.